### PR TITLE
Change SelectTab name

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -25,8 +25,8 @@
 			"enable-if": "activate"
 		},
 		"separateTab": {
-			"name": "Remove objects from normal tabs",
-			"description": "Chooses where to add the objects.",
+			"name": "Add objects to...",
+			"description": "Chooses which tab to add the objects on.",
 			"type": "string",
 			"enable-if": "activate",
 			"default": "Normal Tabs",


### PR DESCRIPTION
Change the name of the SelectTab option from "Remove objects from normal tabs" to "Add objects to..." to make it more intuitive